### PR TITLE
Update urllib3 version due to vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ certifi >= 14.05.14
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 2.6.3
 Deprecated >= 1.2.13


### PR DESCRIPTION
# Code Changes Needed #
On December 5, a deployment triggered a breaking change in an upstream dependency (urllib3) required by the SCORM Cloud SDK. The SCORM SDK (rustici_software_cloud_v2) depends on HTTPResponse.getheader(), a method that was removed in urllib3 v2.6. The deployment inadvertently upgraded urllib3 from version 2.5 to version 2.6, immediately breaking SCORM API calls.

## Impact ##
urllib3 supports chained HTTP encoding algorithms for response content according to RFC 9110 (e.g., Content-Encoding: gzip, zstd).

However, the number of links in the decompression chain was unbounded allowing a malicious server to insert a virtually unlimited number of compression steps leading to high CPU usage and massive memory allocation for the decompressed data.

## Affected usages ##
Applications and libraries using urllib3 version 2.5.0 and earlier for HTTP requests to untrusted sources unless they disable content decoding explicitly.

## Remediation ##
Upgrade to at least urllib3 v2.6.3 in which the library limits the number of links to 5.

If upgrading is not immediately possible, use [preload_content=False](https://urllib3.readthedocs.io/en/2.5.0/advanced-usage.html#streaming-and-i-o) and ensure that resp.headers["content-encoding"] contains a safe number of encodings before reading the response content.